### PR TITLE
Small Fix for <error> host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /pkg/*.zip
 /terraform-inventory
 .idea
+
+state.json

--- a/parser.go
+++ b/parser.go
@@ -108,7 +108,11 @@ func (s *state) outputs() []*Output {
 			case string:
 				o, _ = NewOutput(k, v)
 			default:
-				o, _ = NewOutput(k, "<error>")
+				continue
+			}
+
+			if strings.Contains(fmt.Sprint(o.value), "error") {
+				continue
 			}
 
 			inst = append(inst, o)
@@ -128,7 +132,7 @@ func (s *stateTerraform0dot12) outputs() []*Output {
 		case map[string]interface{}:
 			o, _ = NewOutput(k, v["value"])
 		default: // not expected
-			o, _ = NewOutput(k, "<error>")
+			continue
 		}
 
 		inst = append(inst, o)
@@ -281,7 +285,7 @@ func encodeTerraform0Dot12ValuesAsAttributes(rawValues *map[string]interface{}) 
 				if str, typeOk := vv.(string); typeOk {
 					ret[k+"."+kk] = str
 				} else {
-					ret[k+"."+kk] = "<error>"
+					continue
 				}
 			}
 		case []interface{}:
@@ -295,17 +299,17 @@ func encodeTerraform0Dot12ValuesAsAttributes(rawValues *map[string]interface{}) 
 						if str, typeOk := vvv.(string); typeOk {
 							ret[k+"."+strconv.Itoa(kk)+"."+kkk] = str
 						} else {
-							ret[k+"."+strconv.Itoa(kk)+"."+kkk] = "<error>"
+							continue
 						}
 					}
 				default:
-					ret[k+"."+strconv.Itoa(kk)] = "<error>"
+					continue
 				}
 			}
 		case string:
 			ret[k] = v
 		default:
-			ret[k] = "<error>"
+			continue
 		}
 	}
 	return ret


### PR DESCRIPTION
Seems that in a number of cases, terraform-inventory was injecting a host called `<error>` in scenarios where it wasn't able to properly parse a particular resource/host. Ansible doesn't like this, so even if you have 1000 hosts, your playbook will still be marked as "failed" because it tried to connect to the `<error>` host.

IMO, it'd be better to simply not include the host that we failed to parse. Could be good to somehow flag this to the user, but I would need to look into how `ansible-inventory` would prefer that we do that.

For now, we're just "continuing" and not injecting a failed host. This ensures that playbooks run in things like CI/CD are not erroneously marked as failed.